### PR TITLE
Improve variant details display on selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,6 +150,15 @@
       "Ossification"
     ];
 
+    function changeVariant(button, index, price, condition) {
+      const card = button.closest('.card');
+      card.querySelectorAll('.variant-image').forEach((img, i) =>
+        img.classList.toggle('active', i === index)
+      );
+      card.querySelector('.price').textContent = `Price: ${price}`;
+      card.querySelector('.condition').textContent = `Condition: ${condition}`;
+    }
+
     async function fetchCardImages() {
       const grid = document.getElementById("cardGrid");
       for (let name of cardNames) {
@@ -167,14 +176,14 @@
           </div>
           <div class="overlay">
             <div>
-              <div>Price: $29.99</div>
+              <div class="price">Price: $29.99</div>
               <div>Rarity: Mythic</div>
-              <div>Condition: NM</div>
+              <div class="condition">Condition: NM</div>
               <div>Live Inventory: 4 copies</div>
               <div class="variant-selector">
-                <button onclick="this.closest('.card').querySelectorAll('.variant-image').forEach((img,i)=>img.classList.toggle('active', i===0))">$29.99 - NM</button>
-                <button onclick="this.closest('.card').querySelectorAll('.variant-image').forEach((img,i)=>img.classList.toggle('active', i===1))">$27.50 - EX</button>
-                <button onclick="this.closest('.card').querySelectorAll('.variant-image').forEach((img,i)=>img.classList.toggle('active', i===2))">$24.99 - LP</button>
+                <button onclick="changeVariant(this, 0, '$29.99', 'NM')">$29.99 - NM</button>
+                <button onclick="changeVariant(this, 1, '$27.50', 'EX')">$27.50 - EX</button>
+                <button onclick="changeVariant(this, 2, '$24.99', 'LP')">$24.99 - LP</button>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Update variant selection to change card image, price, and condition text together

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac089da83c8333a91ab632270669e8