### PR TITLE
Add DOM test for fetchCardImages

### DIFF
--- a/fetchCardImages.js
+++ b/fetchCardImages.js
@@ -1,0 +1,53 @@
+const cardNames = [
+  "Teferi, Hero of Dominaria",
+  "Liliana of the Veil",
+  "Sheoldred, the Apocalypse",
+  "Cut Down",
+  "Go for the Throat",
+  "Cavern of Souls",
+  "Arcane Signet",
+  "Boseiju, Who Endures",
+  "Command Tower",
+  "Ossification"
+];
+
+async function fetchCardImages() {
+  const grid = document.getElementById("cardGrid");
+  for (let name of cardNames) {
+    const res = await fetch(`https://api.scryfall.com/cards/named?exact=${encodeURIComponent(name)}`);
+    const data = await res.json();
+    const image = data.image_uris.normal;
+
+    const cardDiv = document.createElement("div");
+    cardDiv.className = "card";
+    cardDiv.innerHTML = `
+      <div class="card-stack">
+        <img class="variant-image active" src="${image}" alt="${name} NM">
+        <img class="variant-image" src="${image}" alt="${name} EX">
+        <img class="variant-image" src="${image}" alt="${name} LP">
+      </div>
+      <div class="overlay">
+        <div>
+          <div class="price">Price: $29.99</div>
+          <div>Rarity: Mythic</div>
+          <div class="condition">Condition: NM</div>
+          <div>Live Inventory: 4 copies</div>
+          <div class="variant-selector">
+            <button onclick="changeVariant(this, 0, '$29.99', 'NM')">$29.99 - NM</button>
+            <button onclick="changeVariant(this, 1, '$27.50', 'EX')">$27.50 - EX</button>
+            <button onclick="changeVariant(this, 2, '$24.99', 'LP')">$24.99 - LP</button>
+          </div>
+        </div>
+      </div>
+    `;
+    grid.appendChild(cardDiv);
+  }
+}
+
+// UMD-style export so function is available in browser and Node tests
+if (typeof module !== 'undefined') {
+  module.exports = { fetchCardImages, cardNames };
+} else {
+  window.fetchCardImages = fetchCardImages;
+  window.cardNames = cardNames;
+}

--- a/index.html
+++ b/index.html
@@ -136,63 +136,18 @@
       </div>
     </div>
   </div>
-  <script>
-    const cardNames = [
-      "Teferi, Hero of Dominaria",
-      "Liliana of the Veil",
-      "Sheoldred, the Apocalypse",
-      "Cut Down",
-      "Go for the Throat",
-      "Cavern of Souls",
-      "Arcane Signet",
-      "Boseiju, Who Endures",
-      "Command Tower",
-      "Ossification"
-    ];
-
-    function changeVariant(button, index, price, condition) {
-      const card = button.closest('.card');
-      card.querySelectorAll('.variant-image').forEach((img, i) =>
-        img.classList.toggle('active', i === index)
-      );
-      card.querySelector('.price').textContent = `Price: ${price}`;
-      card.querySelector('.condition').textContent = `Condition: ${condition}`;
-    }
-
-    async function fetchCardImages() {
-      const grid = document.getElementById("cardGrid");
-      for (let name of cardNames) {
-        const res = await fetch(`https://api.scryfall.com/cards/named?exact=${encodeURIComponent(name)}`);
-        const data = await res.json();
-        const image = data.image_uris.normal;
-
-        const cardDiv = document.createElement("div");
-        cardDiv.className = "card";
-        cardDiv.innerHTML = `
-          <div class="card-stack">
-            <img class="variant-image active" src="${image}" alt="${name} NM">
-            <img class="variant-image" src="${image}" alt="${name} EX">
-            <img class="variant-image" src="${image}" alt="${name} LP">
-          </div>
-          <div class="overlay">
-            <div>
-              <div class="price">Price: $29.99</div>
-              <div>Rarity: Mythic</div>
-              <div class="condition">Condition: NM</div>
-              <div>Live Inventory: 4 copies</div>
-              <div class="variant-selector">
-                <button onclick="changeVariant(this, 0, '$29.99', 'NM')">$29.99 - NM</button>
-                <button onclick="changeVariant(this, 1, '$27.50', 'EX')">$27.50 - EX</button>
-                <button onclick="changeVariant(this, 2, '$24.99', 'LP')">$24.99 - LP</button>
-              </div>
-            </div>
-          </div>
-        `;
-        grid.appendChild(cardDiv);
+    <script src="fetchCardImages.js"></script>
+    <script>
+      function changeVariant(button, index, price, condition) {
+        const card = button.closest('.card');
+        card.querySelectorAll('.variant-image').forEach((img, i) =>
+          img.classList.toggle('active', i === index)
+        );
+        card.querySelector('.price').textContent = `Price: ${price}`;
+        card.querySelector('.condition').textContent = `Condition: ${condition}`;
       }
-    }
 
-    fetchCardImages();
-  </script>
+      fetchCardImages();
+    </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "card-bazaar",
+  "version": "1.0.0",
+  "description": "Card Bazaar is a Magic: The Gathering singles marketplace concept site.   This version (1.3 FIXED) fetches live card images from the [Scryfall API](https://scryfall.com/docs/api)   and displays them in a two-column grid with interactive hover overlays showing pricing and condition variants.",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}

--- a/tests/fetchCardImages.test.js
+++ b/tests/fetchCardImages.test.js
@@ -1,0 +1,23 @@
+const { fetchCardImages, cardNames } = require('../fetchCardImages');
+
+describe('fetchCardImages', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="cardGrid"></div>';
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({ image_uris: { normal: 'test-image.png' } })
+      })
+    );
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('adds one card per name', async () => {
+    await fetchCardImages();
+    const grid = document.getElementById('cardGrid');
+    expect(grid.children).toHaveLength(cardNames.length);
+  });
+});


### PR DESCRIPTION
## Summary
- move card image fetching logic to `fetchCardImages.js` and expose for tests
- call `fetchCardImages` from `index.html`
- add Jest test that mocks Scryfall fetch and checks grid children

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0a9810fc8333a7ee2a4b274751fb