### PR TITLE
Show card stack on hover

### DIFF
--- a/fetchCardImages.js
+++ b/fetchCardImages.js
@@ -43,7 +43,8 @@ async function fetchCardImages() {
       </div>
     `;
     const stack = cardDiv.querySelector('.card-stack');
-    stack.addEventListener('click', () => stack.classList.toggle('show-stack'));
+    cardDiv.addEventListener('mouseenter', () => stack.classList.add('show-stack'));
+    cardDiv.addEventListener('mouseleave', () => stack.classList.remove('show-stack'));
     grid.appendChild(cardDiv);
   }
 }


### PR DESCRIPTION
## Summary
- Reveal the stack of card condition variants when hovering over a card
- Keep selected condition images on top when variants are chosen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac25d4fab083338f1148fa276e1238