### PR TITLE
Enable selectable stacked card variants

### DIFF
--- a/fetchCardImages.js
+++ b/fetchCardImages.js
@@ -18,32 +18,50 @@ async function fetchCardImages() {
     const data = await res.json();
     const image = data.image_uris.normal;
 
+    const variants = [
+      { condition: 'NM', price: '$29.99' },
+      { condition: 'EX', price: '$27.50' },
+      { condition: 'LP', price: '$24.99' },
+      { condition: 'HP', price: '$19.99' }
+    ];
+
     const cardDiv = document.createElement("div");
     cardDiv.className = "card";
     cardDiv.innerHTML = `
       <div class="card-stack">
-        <img class="variant-image active" data-condition="NM" src="${image}" alt="${name} NM">
-        <img class="variant-image" data-condition="EX" src="${image}" alt="${name} EX">
-        <img class="variant-image" data-condition="LP" src="${image}" alt="${name} LP">
-        <img class="variant-image" data-condition="HP" src="${image}" alt="${name} HP">
+        ${variants
+          .map(
+            (v, i) =>
+              `<img class="variant-image${i === 0 ? ' active' : ''}" data-condition="${v.condition}" data-price="${v.price}" src="${image}" alt="${name} ${v.condition}">`
+          )
+          .join('')}
       </div>
       <div class="overlay">
         <div>
-          <div class="price">Price: $29.99</div>
+          <div class="price">Price: ${variants[0].price}</div>
           <div>Rarity: Mythic</div>
-          <div class="condition">Condition: NM</div>
+          <div class="condition">Condition: ${variants[0].condition}</div>
           <div>Live Inventory: 4 copies</div>
           <div class="variant-selector">
-            <button onclick="changeVariant(this, 'NM', '$29.99')">$29.99 - NM</button>
-            <button onclick="changeVariant(this, 'EX', '$27.50')">$27.50 - EX</button>
-            <button onclick="changeVariant(this, 'LP', '$24.99')">$24.99 - LP</button>
-            <button onclick="changeVariant(this, 'HP', '$19.99')">$19.99 - HP</button>
+            ${variants
+              .map(
+                v =>
+                  `<button onclick="changeVariant(this, '${v.condition}', '${v.price}')">${v.price} - ${v.condition}</button>`
+              )
+              .join('')}
           </div>
         </div>
       </div>
     `;
+
     const stack = cardDiv.querySelector('.card-stack');
-    stack.addEventListener('click', () => stack.classList.toggle('show-stack'));
+    cardDiv.addEventListener('mouseenter', () => stack.classList.add('show-stack'));
+    cardDiv.addEventListener('mouseleave', () => stack.classList.remove('show-stack'));
+    stack.querySelectorAll('.variant-image').forEach(img => {
+      img.addEventListener('click', () =>
+        changeVariant(img, img.dataset.condition, img.dataset.price)
+      );
+    });
     grid.appendChild(cardDiv);
   }
 }

--- a/index.html
+++ b/index.html
@@ -68,24 +68,28 @@
       object-fit: contain;
       display: block;
     }
-    .overlay {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      background-color: rgba(0, 0, 0, 0.75);
-      color: white;
-      display: none;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
-      font-size: 20px;
-      z-index: 2;
-    }
-    .card:hover .overlay {
-      display: flex;
-    }
+      .overlay {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: rgba(0, 0, 0, 0.5);
+        color: white;
+        display: none;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        font-size: 20px;
+        z-index: 2;
+        pointer-events: none;
+      }
+      .overlay > div {
+        pointer-events: auto;
+      }
+      .card:hover .overlay {
+        display: flex;
+      }
     .variant-selector {
       margin-top: 12px;
       display: flex;
@@ -100,27 +104,32 @@
       border: none;
       cursor: pointer;
     }
-    .card-stack {
-      position: relative;
-      width: 512px;
-      height: 716px;
-    }
-    .variant-image {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      opacity: 0;
-      transition: opacity 0.3s ease-in-out, transform 0.3s ease-in-out;
-      object-fit: contain;
-    }
-    .variant-image.active {
-      opacity: 1;
-    }
-    .card-stack.show-stack .variant-image {
-      opacity: 1;
-    }
+      .card-stack {
+        position: relative;
+        width: 512px;
+        height: 716px;
+        transition: transform 0.3s ease-in-out;
+      }
+      .variant-image {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        opacity: 0;
+        transition: opacity 0.3s ease-in-out, transform 0.3s ease-in-out;
+        object-fit: contain;
+        cursor: pointer;
+      }
+      .variant-image.active {
+        opacity: 1;
+      }
+      .card-stack.show-stack {
+        transform: translateY(-10px);
+      }
+      .card-stack.show-stack .variant-image {
+        opacity: 1;
+      }
     .card-stack.show-stack .variant-image:nth-child(1) {
       transform: translate(-15px, 15px) rotate(-3deg);
     }

--- a/tests/fetchCardImages.test.js
+++ b/tests/fetchCardImages.test.js
@@ -83,48 +83,64 @@ function el(tag, className) {
   return e;
 }
 
-function buildCard() {
-  const card = el('div', 'card');
-  const stack = el('div', 'card-stack');
-  const price = el('div', 'price');
-  price.textContent = 'Price: $29.99';
-  const condition = el('div', 'condition');
-  condition.textContent = 'Condition: NM';
-  card.appendChild(stack);
-  card.appendChild(price);
-  card.appendChild(condition);
+  function buildCard() {
+    const card = el('div', 'card');
+    const stack = el('div', 'card-stack');
+    const price = el('div', 'price');
+    price.textContent = 'Price: $29.99';
+    const condition = el('div', 'condition');
+    condition.textContent = 'Condition: NM';
+    card.appendChild(stack);
+    card.appendChild(price);
+    card.appendChild(condition);
 
-  const variants = ['NM', 'EX', 'LP', 'HP'].map(cond => {
-    const img = el('img', 'variant-image');
-    img.dataset.condition = cond;
-    stack.appendChild(img);
-    return img;
+    const prices = { NM: '$29.99', EX: '$27.50', LP: '$24.99', HP: '$19.99' };
+    const variants = ['NM', 'EX', 'LP', 'HP'].map(cond => {
+      const img = el('img', 'variant-image');
+      img.dataset.condition = cond;
+      img.dataset.price = prices[cond];
+      stack.appendChild(img);
+      return img;
+    });
+    variants[0].classList.add('active');
+
+    const selector = el('div', 'variant-selector');
+    const buttons = ['NM', 'EX', 'LP', 'HP'].map(cond => {
+      const btn = el('button');
+      btn.dataset.condition = cond;
+      selector.appendChild(btn);
+      return btn;
+    });
+    card.appendChild(selector);
+
+    return { card, stack, price, condition, buttons, variants };
+  }
+
+  test('changeVariant reorders stack and updates labels via buttons', () => {
+    const { stack, price, condition, buttons } = buildCard();
+
+    changeVariant(buttons[2], 'LP', '$24.99');
+    assert.equal(stack.lastElementChild.dataset.condition, 'LP');
+    assert.equal(stack.querySelector('.variant-image.active').dataset.condition, 'LP');
+    assert.equal(price.textContent, 'Price: $24.99');
+    assert.equal(condition.textContent, 'Condition: LP');
+
+    changeVariant(buttons[3], 'HP', '$19.99');
+    assert.equal(stack.lastElementChild.dataset.condition, 'HP');
+    assert.equal(stack.querySelector('.variant-image.active').dataset.condition, 'HP');
+    assert.equal(price.textContent, 'Price: $19.99');
+    assert.equal(condition.textContent, 'Condition: HP');
+
+    assert.equal(stack.querySelectorAll('.variant-image').length, 4);
   });
-  variants[0].classList.add('active');
 
-  const selector = el('div', 'variant-selector');
-  const buttons = ['NM', 'EX', 'LP', 'HP'].map(() => el('button'));
-  buttons.forEach(btn => selector.appendChild(btn));
-  card.appendChild(selector);
+  test('changeVariant works when clicking variant images', () => {
+    const { stack, price, condition, variants } = buildCard();
 
-  return { card, stack, price, condition, buttons };
-}
-
-test('changeVariant reorders stack and updates labels', () => {
-  const { card, stack, price, condition, buttons } = buildCard();
-
-  changeVariant(buttons[2], 'LP', '$24.99');
-  assert.equal(stack.lastElementChild.dataset.condition, 'LP');
-  assert.equal(stack.querySelector('.variant-image.active').dataset.condition, 'LP');
-  assert.equal(price.textContent, 'Price: $24.99');
-  assert.equal(condition.textContent, 'Condition: LP');
-
-  changeVariant(buttons[3], 'HP', '$19.99');
-  assert.equal(stack.lastElementChild.dataset.condition, 'HP');
-  assert.equal(stack.querySelector('.variant-image.active').dataset.condition, 'HP');
-  assert.equal(price.textContent, 'Price: $19.99');
-  assert.equal(condition.textContent, 'Condition: HP');
-
-  assert.equal(stack.querySelectorAll('.variant-image').length, 4);
-});
+    changeVariant(variants[1], 'EX', '$27.50');
+    assert.equal(stack.lastElementChild.dataset.condition, 'EX');
+    assert.equal(stack.querySelector('.variant-image.active').dataset.condition, 'EX');
+    assert.equal(price.textContent, 'Price: $27.50');
+    assert.equal(condition.textContent, 'Condition: EX');
+  });
 


### PR DESCRIPTION
## Summary
- Render four condition images in a fanned stack that lifts on hover
- Allow clicking any card in the stack to select its condition and reorder the stack
- Add tests for variant selection via images

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac25d4fab083338f1148fa276e1238