### PR TITLE
Enable clickable card stack on hover

### DIFF
--- a/fetchCardImages.js
+++ b/fetchCardImages.js
@@ -11,6 +11,13 @@ const cardNames = [
   "Ossification"
 ];
 
+const prices = {
+  NM: '$29.99',
+  EX: '$27.50',
+  LP: '$24.99',
+  HP: '$19.99'
+};
+
 async function fetchCardImages() {
   const grid = document.getElementById("cardGrid");
   for (let name of cardNames) {
@@ -22,29 +29,30 @@ async function fetchCardImages() {
     cardDiv.className = "card";
     cardDiv.innerHTML = `
       <div class="card-stack">
-        <img class="variant-image active" data-condition="NM" src="${image}" alt="${name} NM">
-        <img class="variant-image" data-condition="EX" src="${image}" alt="${name} EX">
-        <img class="variant-image" data-condition="LP" src="${image}" alt="${name} LP">
-        <img class="variant-image" data-condition="HP" src="${image}" alt="${name} HP">
+        <img class="variant-image active" data-condition="NM" data-price="${prices.NM}" src="${image}" alt="${name} NM">
+        <img class="variant-image" data-condition="EX" data-price="${prices.EX}" src="${image}" alt="${name} EX">
+        <img class="variant-image" data-condition="LP" data-price="${prices.LP}" src="${image}" alt="${name} LP">
+        <img class="variant-image" data-condition="HP" data-price="${prices.HP}" src="${image}" alt="${name} HP">
       </div>
       <div class="overlay">
         <div>
-          <div class="price">Price: $29.99</div>
+          <div class="price">Price: ${prices.NM}</div>
           <div>Rarity: Mythic</div>
           <div class="condition">Condition: NM</div>
           <div>Live Inventory: 4 copies</div>
-          <div class="variant-selector">
-            <button onclick="changeVariant(this, 'NM', '$29.99')">$29.99 - NM</button>
-            <button onclick="changeVariant(this, 'EX', '$27.50')">$27.50 - EX</button>
-            <button onclick="changeVariant(this, 'LP', '$24.99')">$24.99 - LP</button>
-            <button onclick="changeVariant(this, 'HP', '$19.99')">$19.99 - HP</button>
-          </div>
         </div>
       </div>
     `;
     const stack = cardDiv.querySelector('.card-stack');
     cardDiv.addEventListener('mouseenter', () => stack.classList.add('show-stack'));
     cardDiv.addEventListener('mouseleave', () => stack.classList.remove('show-stack'));
+
+    stack.querySelectorAll('.variant-image').forEach(img => {
+      img.addEventListener('click', () => {
+        changeVariant(img, img.dataset.condition, img.dataset.price);
+      });
+    });
+
     grid.appendChild(cardDiv);
   }
 }

--- a/index.html
+++ b/index.html
@@ -82,28 +82,16 @@
       align-items: center;
       font-size: 20px;
       z-index: 2;
+      pointer-events: none;
     }
     .card:hover .overlay {
       display: flex;
-    }
-    .variant-selector {
-      margin-top: 12px;
-      display: flex;
-      gap: 12px;
-      flex-wrap: wrap;
-    }
-    .variant-selector button {
-      padding: 4px 8px;
-      font-size: 12px;
-      background-color: white;
-      color: #000;
-      border: none;
-      cursor: pointer;
     }
     .card-stack {
       position: relative;
       width: 512px;
       height: 716px;
+      transition: transform 0.3s ease-in-out;
     }
     .variant-image {
       position: absolute;
@@ -114,12 +102,16 @@
       opacity: 0;
       transition: opacity 0.3s ease-in-out, transform 0.3s ease-in-out;
       object-fit: contain;
+      cursor: pointer;
     }
     .variant-image.active {
       opacity: 1;
     }
     .card-stack.show-stack .variant-image {
       opacity: 1;
+    }
+    .card-stack.show-stack {
+      transform: translateY(-20px) rotate(-3deg);
     }
     .card-stack.show-stack .variant-image:nth-child(1) {
       transform: translate(-15px, 15px) rotate(-3deg);
@@ -153,9 +145,6 @@
   </div>
     <script src="fetchCardImages.js"></script>
     <script>
-      function changeVariant(button, condition, price) {
-        window.changeVariant(button, condition, price);
-      }
       fetchCardImages();
     </script>
 </body>


### PR DESCRIPTION
## Summary
- Allow card stacks to fan out and lift when hovered.
- Make stacked card images clickable to switch condition and update price.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac3286d1a08333a686cbed9893ccc5