### PR TITLE
Enable clickable card stack on hover

### DIFF
--- a/fetchCardImages.js
+++ b/fetchCardImages.js
@@ -11,6 +11,13 @@ const cardNames = [
   "Ossification"
 ];
 
+const prices = {
+  NM: '$29.99',
+  EX: '$27.50',
+  LP: '$24.99',
+  HP: '$19.99'
+};
+
 async function fetchCardImages() {
   const grid = document.getElementById("cardGrid");
   for (let name of cardNames) {
@@ -22,29 +29,35 @@ async function fetchCardImages() {
     cardDiv.className = "card";
     cardDiv.innerHTML = `
       <div class="card-stack">
-        <img class="variant-image active" data-condition="NM" src="${image}" alt="${name} NM">
-        <img class="variant-image" data-condition="EX" src="${image}" alt="${name} EX">
-        <img class="variant-image" data-condition="LP" src="${image}" alt="${name} LP">
-        <img class="variant-image" data-condition="HP" src="${image}" alt="${name} HP">
+        <img class="variant-image active" data-condition="NM" data-price="${prices.NM}" src="${image}" alt="${name} NM">
+        <img class="variant-image" data-condition="EX" data-price="${prices.EX}" src="${image}" alt="${name} EX">
+        <img class="variant-image" data-condition="LP" data-price="${prices.LP}" src="${image}" alt="${name} LP">
+        <img class="variant-image" data-condition="HP" data-price="${prices.HP}" src="${image}" alt="${name} HP">
       </div>
       <div class="overlay">
         <div>
-          <div class="price">Price: $29.99</div>
+          <div class="price">Price: ${prices.NM}</div>
           <div>Rarity: Mythic</div>
           <div class="condition">Condition: NM</div>
           <div>Live Inventory: 4 copies</div>
-          <div class="variant-selector">
-            <button onclick="changeVariant(this, 'NM', '$29.99')">$29.99 - NM</button>
-            <button onclick="changeVariant(this, 'EX', '$27.50')">$27.50 - EX</button>
-            <button onclick="changeVariant(this, 'LP', '$24.99')">$24.99 - LP</button>
-            <button onclick="changeVariant(this, 'HP', '$19.99')">$19.99 - HP</button>
-          </div>
         </div>
       </div>
     `;
     const stack = cardDiv.querySelector('.card-stack');
     cardDiv.addEventListener('mouseenter', () => stack.classList.add('show-stack'));
     cardDiv.addEventListener('mouseleave', () => stack.classList.remove('show-stack'));
+
+    stack.addEventListener('click', (e) => {
+      const images = Array.from(stack.querySelectorAll('.variant-image'));
+      if (e.target.classList.contains('variant-image') && !e.target.classList.contains('active')) {
+        changeVariant(e.target, e.target.dataset.condition, e.target.dataset.price);
+      } else {
+        const activeIndex = images.findIndex(img => img.classList.contains('active'));
+        const next = images[(activeIndex + 1) % images.length];
+        changeVariant(next, next.dataset.condition, next.dataset.price);
+      }
+    });
+
     grid.appendChild(cardDiv);
   }
 }

--- a/index.html
+++ b/index.html
@@ -82,28 +82,16 @@
       align-items: center;
       font-size: 20px;
       z-index: 2;
+      pointer-events: none;
     }
     .card:hover .overlay {
       display: flex;
-    }
-    .variant-selector {
-      margin-top: 12px;
-      display: flex;
-      gap: 12px;
-      flex-wrap: wrap;
-    }
-    .variant-selector button {
-      padding: 4px 8px;
-      font-size: 12px;
-      background-color: white;
-      color: #000;
-      border: none;
-      cursor: pointer;
     }
     .card-stack {
       position: relative;
       width: 512px;
       height: 716px;
+      transition: transform 0.2s ease-in-out;
     }
     .variant-image {
       position: absolute;
@@ -112,8 +100,9 @@
       width: 100%;
       height: 100%;
       opacity: 0;
-      transition: opacity 0.3s ease-in-out, transform 0.3s ease-in-out;
+      transition: opacity 0.2s ease-in-out, transform 0.2s ease-in-out;
       object-fit: contain;
+      cursor: pointer;
     }
     .variant-image.active {
       opacity: 1;
@@ -121,17 +110,24 @@
     .card-stack.show-stack .variant-image {
       opacity: 1;
     }
+    .card-stack.show-stack {
+      transform: translateY(-10px);
+    }
     .card-stack.show-stack .variant-image:nth-child(1) {
-      transform: translate(-15px, 15px) rotate(-3deg);
+      transform: translate(-8px, 6px) rotate(-2deg);
+      z-index: 1;
     }
     .card-stack.show-stack .variant-image:nth-child(2) {
-      transform: translate(-5px, 5px) rotate(2deg);
+      transform: translate(-4px, 3px) rotate(-1deg);
+      z-index: 2;
     }
     .card-stack.show-stack .variant-image:nth-child(3) {
-      transform: translate(5px, -5px) rotate(-2deg);
+      transform: translate(4px, -3px) rotate(1deg);
+      z-index: 3;
     }
     .card-stack.show-stack .variant-image:nth-child(4) {
-      transform: translate(15px, -15px) rotate(1deg);
+      transform: translate(8px, -6px) rotate(2deg);
+      z-index: 4;
     }
   </style>
   <link href="https://fonts.googleapis.com/css2?family=Bangers&display=swap" rel="stylesheet">
@@ -153,9 +149,6 @@
   </div>
     <script src="fetchCardImages.js"></script>
     <script>
-      function changeVariant(button, condition, price) {
-        window.changeVariant(button, condition, price);
-      }
       fetchCardImages();
     </script>
 </body>


### PR DESCRIPTION
## Summary
- Subtly fan out card stacks on hover so all variants peek behind the front card
- Clicking the stack cycles through card conditions, or choose a visible card directly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac3286d1a08333a686cbed9893ccc5