### PR TITLE
Enable card stack cycling with subtle hover effect

### DIFF
--- a/fetchCardImages.js
+++ b/fetchCardImages.js
@@ -48,10 +48,12 @@ async function fetchCardImages() {
     cardDiv.addEventListener('mouseleave', () => stack.classList.remove('show-stack'));
 
     stack.querySelectorAll('.variant-image').forEach(img => {
-      img.addEventListener('click', () => {
+      img.addEventListener('click', (e) => {
+        e.stopPropagation();
         changeVariant(img, img.dataset.condition, img.dataset.price);
       });
     });
+    stack.addEventListener('click', () => cycleVariant(stack));
 
     grid.appendChild(cardDiv);
   }
@@ -69,11 +71,19 @@ function changeVariant(button, condition, price) {
   card.querySelector('.condition').textContent = `Condition: ${condition}`;
 }
 
+function cycleVariant(stack) {
+  const images = Array.from(stack.querySelectorAll('.variant-image'));
+  const activeIndex = images.findIndex(img => img.classList.contains('active'));
+  const next = images[(activeIndex + 1) % images.length];
+  changeVariant(next, next.dataset.condition, next.dataset.price);
+}
+
 // UMD-style export so function is available in browser and Node tests
 if (typeof module !== 'undefined') {
-  module.exports = { fetchCardImages, cardNames, changeVariant };
+  module.exports = { fetchCardImages, cardNames, changeVariant, cycleVariant };
 } else {
   window.fetchCardImages = fetchCardImages;
   window.cardNames = cardNames;
   window.changeVariant = changeVariant;
+  window.cycleVariant = cycleVariant;
 }

--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
       left: 0;
       width: 100%;
       height: 100%;
-      background-color: rgba(0, 0, 0, 0.75);
+      background-color: rgba(0, 0, 0, 0.6);
       color: white;
       display: none;
       flex-direction: column;
@@ -111,19 +111,19 @@
       opacity: 1;
     }
     .card-stack.show-stack {
-      transform: translateY(-20px) rotate(-3deg);
+      transform: translateY(-5px) rotate(-1deg);
     }
     .card-stack.show-stack .variant-image:nth-child(1) {
-      transform: translate(-15px, 15px) rotate(-3deg);
+      transform: translate(-6px, 6px) rotate(-1deg);
     }
     .card-stack.show-stack .variant-image:nth-child(2) {
-      transform: translate(-5px, 5px) rotate(2deg);
+      transform: translate(-2px, 2px) rotate(1deg);
     }
     .card-stack.show-stack .variant-image:nth-child(3) {
-      transform: translate(5px, -5px) rotate(-2deg);
+      transform: translate(2px, -2px) rotate(-0.5deg);
     }
     .card-stack.show-stack .variant-image:nth-child(4) {
-      transform: translate(15px, -15px) rotate(1deg);
+      transform: translate(6px, -6px) rotate(0.5deg);
     }
   </style>
   <link href="https://fonts.googleapis.com/css2?family=Bangers&display=swap" rel="stylesheet">

--- a/tests/fetchCardImages.test.js
+++ b/tests/fetchCardImages.test.js
@@ -1,6 +1,6 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { changeVariant } = require('../fetchCardImages');
+const { changeVariant, cycleVariant } = require('../fetchCardImages');
 
 class Element {
   constructor(tag) {
@@ -94,9 +94,11 @@ function buildCard() {
   card.appendChild(price);
   card.appendChild(condition);
 
+  const priceMap = { NM: '$29.99', EX: '$27.50', LP: '$24.99', HP: '$19.99' };
   const variants = ['NM', 'EX', 'LP', 'HP'].map(cond => {
     const img = el('img', 'variant-image');
     img.dataset.condition = cond;
+    img.dataset.price = priceMap[cond];
     stack.appendChild(img);
     return img;
   });
@@ -126,5 +128,14 @@ test('changeVariant reorders stack and updates labels', () => {
   assert.equal(condition.textContent, 'Condition: HP');
 
   assert.equal(stack.querySelectorAll('.variant-image').length, 4);
+});
+
+test('cycleVariant advances to next image', () => {
+  const { stack, price, condition } = buildCard();
+  cycleVariant(stack);
+  assert.equal(stack.lastElementChild.dataset.condition, 'EX');
+  assert.equal(stack.querySelector('.variant-image.active').dataset.condition, 'EX');
+  assert.equal(price.textContent, 'Price: $27.50');
+  assert.equal(condition.textContent, 'Condition: EX');
 });
 


### PR DESCRIPTION
## Summary
- Allow clicking anywhere on a card stack to cycle through condition variants
- Tone down hover styling for a gentler stacked-card effect
- Cover card cycling behavior in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac93566d9483339e91b1642bd7f4c3