### PR TITLE
Add interactive card stack overlay with grading selector

### DIFF
--- a/fetchCardImages.js
+++ b/fetchCardImages.js
@@ -35,17 +35,32 @@ async function fetchCardImages() {
         <img class="variant-image" data-condition="HP" data-price="${prices.HP}" src="${image}" alt="${name} HP">
       </div>
       <div class="overlay">
-        <div>
+        <div class="info">
           <div class="price">Price: ${prices.NM}</div>
           <div>Rarity: Mythic</div>
           <div class="condition">Condition: NM</div>
           <div>Live Inventory: 4 copies</div>
         </div>
+        <div class="variant-selector">
+          <button data-condition="NM" data-price="${prices.NM}">NM</button>
+          <button data-condition="EX" data-price="${prices.EX}">EX</button>
+          <button data-condition="LP" data-price="${prices.LP}">LP</button>
+          <button data-condition="HP" data-price="${prices.HP}">HP</button>
+        </div>
       </div>
     `;
     const stack = cardDiv.querySelector('.card-stack');
-    cardDiv.addEventListener('mouseenter', () => stack.classList.add('show-stack'));
-    cardDiv.addEventListener('mouseleave', () => stack.classList.remove('show-stack'));
+
+    cardDiv.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const active = document.querySelector('.card.active');
+      if (active && active !== cardDiv) {
+        active.classList.remove('active');
+        active.querySelector('.card-stack').classList.remove('show-stack');
+      }
+      cardDiv.classList.toggle('active');
+      stack.classList.toggle('show-stack', cardDiv.classList.contains('active'));
+    });
 
     stack.querySelectorAll('.variant-image').forEach(img => {
       img.addEventListener('click', (e) => {
@@ -53,10 +68,26 @@ async function fetchCardImages() {
         changeVariant(img, img.dataset.condition, img.dataset.price);
       });
     });
-    stack.addEventListener('click', () => cycleVariant(stack));
+    cardDiv.querySelectorAll('.variant-selector button').forEach(btn => {
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        changeVariant(btn, btn.dataset.condition, btn.dataset.price);
+      });
+    });
+    stack.addEventListener('click', (e) => {
+      e.stopPropagation();
+      cycleVariant(stack);
+    });
 
     grid.appendChild(cardDiv);
   }
+
+  document.addEventListener('click', () => {
+    document.querySelectorAll('.card.active').forEach(c => {
+      c.classList.remove('active');
+      c.querySelector('.card-stack').classList.remove('show-stack');
+    });
+  });
 }
 
 function changeVariant(button, condition, price) {

--- a/index.html
+++ b/index.html
@@ -61,12 +61,17 @@
       height: 716px;
       overflow: hidden;
       margin-bottom: 20px;
+      transition: transform 0.3s ease, box-shadow 0.3s ease;
     }
     .card img {
       width: 100%;
       height: 100%;
       object-fit: contain;
       display: block;
+    }
+    .card.active {
+      transform: translateY(-10px) scale(1.02);
+      box-shadow: 0 10px 20px rgba(0, 0, 0, 0.4);
     }
     .overlay {
       position: absolute;
@@ -76,16 +81,20 @@
       height: 100%;
       background-color: rgba(0, 0, 0, 0.6);
       color: white;
-      display: none;
+      opacity: 0;
       flex-direction: column;
-      justify-content: center;
+      justify-content: space-between;
       align-items: center;
       font-size: 20px;
       z-index: 2;
       pointer-events: none;
+      transition: opacity 0.3s ease;
+      padding: 40px 0;
+      box-sizing: border-box;
     }
-    .card:hover .overlay {
-      display: flex;
+    .card.active .overlay {
+      opacity: 1;
+      pointer-events: auto;
     }
     .card-stack {
       position: relative;
@@ -124,6 +133,26 @@
     }
     .card-stack.show-stack .variant-image:nth-child(4) {
       transform: translate(6px, -6px) rotate(0.5deg);
+    }
+    .variant-selector {
+      margin-top: 20px;
+      display: flex;
+      gap: 8px;
+    }
+    .variant-selector button {
+      padding: 6px 10px;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      font-weight: bold;
+      transition: background 0.2s ease;
+    }
+    .variant-selector button:hover {
+      background: #555;
+      color: #fff;
+    }
+    .overlay .info {
+      text-align: center;
     }
   </style>
   <link href="https://fonts.googleapis.com/css2?family=Bangers&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- enhance card component with click-activated overlay and stack animation
- add variant selector buttons for NM/EX/LP/HP that bring chosen card to front

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac9dd11cc083338894436b573744cc