### PR TITLE
feat: improve card stack interactions

### DIFF
--- a/fetchCardImages.js
+++ b/fetchCardImages.js
@@ -13,9 +13,16 @@ const cardNames = [
 
 const prices = {
   NM: '$29.99',
-  EX: '$27.50',
-  LP: '$24.99',
-  HP: '$19.99'
+  VG: '$24.99',
+  EX: '$19.99',
+  G: '$9.99'
+};
+
+const inventory = {
+  NM: 4,
+  VG: 3,
+  EX: 6,
+  G: 2
 };
 
 async function fetchCardImages() {
@@ -30,37 +37,22 @@ async function fetchCardImages() {
     cardDiv.innerHTML = `
       <div class="card-stack">
         <img class="variant-image active" data-condition="NM" data-price="${prices.NM}" src="${image}" alt="${name} NM">
+        <img class="variant-image" data-condition="VG" data-price="${prices.VG}" src="${image}" alt="${name} VG">
         <img class="variant-image" data-condition="EX" data-price="${prices.EX}" src="${image}" alt="${name} EX">
-        <img class="variant-image" data-condition="LP" data-price="${prices.LP}" src="${image}" alt="${name} LP">
-        <img class="variant-image" data-condition="HP" data-price="${prices.HP}" src="${image}" alt="${name} HP">
+        <img class="variant-image" data-condition="G" data-price="${prices.G}" src="${image}" alt="${name} G">
       </div>
-      <div class="overlay">
-        <div class="info">
-          <div class="price">Price: ${prices.NM}</div>
-          <div>Rarity: Mythic</div>
-          <div class="condition">Condition: NM</div>
-          <div>Live Inventory: 4 copies</div>
-        </div>
-        <div class="variant-selector">
-          <button data-condition="NM" data-price="${prices.NM}">NM</button>
-          <button data-condition="EX" data-price="${prices.EX}">EX</button>
-          <button data-condition="LP" data-price="${prices.LP}">LP</button>
-          <button data-condition="HP" data-price="${prices.HP}">HP</button>
-        </div>
+      <div class="info" style="display:none;">
+        <div class="price">Price: ${prices.NM}</div>
+        <div class="condition">Condition: NM</div>
+      </div>
+      <div class="condition-buttons">
+        <button data-condition="NM" data-price="${prices.NM}">NM (${inventory.NM})</button>
+        <button data-condition="VG" data-price="${prices.VG}">VG (${inventory.VG})</button>
+        <button data-condition="EX" data-price="${prices.EX}">EX (${inventory.EX})</button>
+        <button data-condition="G" data-price="${prices.G}">G (${inventory.G})</button>
       </div>
     `;
     const stack = cardDiv.querySelector('.card-stack');
-
-    cardDiv.addEventListener('click', (e) => {
-      e.stopPropagation();
-      const active = document.querySelector('.card.active');
-      if (active && active !== cardDiv) {
-        active.classList.remove('active');
-        active.querySelector('.card-stack').classList.remove('show-stack');
-      }
-      cardDiv.classList.toggle('active');
-      stack.classList.toggle('show-stack', cardDiv.classList.contains('active'));
-    });
 
     stack.querySelectorAll('.variant-image').forEach(img => {
       img.addEventListener('click', (e) => {
@@ -68,26 +60,15 @@ async function fetchCardImages() {
         changeVariant(img, img.dataset.condition, img.dataset.price);
       });
     });
-    cardDiv.querySelectorAll('.variant-selector button').forEach(btn => {
+    cardDiv.querySelectorAll('.condition-buttons button').forEach(btn => {
       btn.addEventListener('click', (e) => {
         e.stopPropagation();
         changeVariant(btn, btn.dataset.condition, btn.dataset.price);
       });
     });
-    stack.addEventListener('click', (e) => {
-      e.stopPropagation();
-      cycleVariant(stack);
-    });
 
     grid.appendChild(cardDiv);
   }
-
-  document.addEventListener('click', () => {
-    document.querySelectorAll('.card.active').forEach(c => {
-      c.classList.remove('active');
-      c.querySelector('.card-stack').classList.remove('show-stack');
-    });
-  });
 }
 
 function changeVariant(button, condition, price) {

--- a/index.html
+++ b/index.html
@@ -69,32 +69,9 @@
       object-fit: contain;
       display: block;
     }
-    .card.active {
+    .card:hover {
       transform: translateY(-10px) scale(1.02);
       box-shadow: 0 10px 20px rgba(0, 0, 0, 0.4);
-    }
-    .overlay {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      background-color: rgba(0, 0, 0, 0.6);
-      color: white;
-      opacity: 0;
-      flex-direction: column;
-      justify-content: space-between;
-      align-items: center;
-      font-size: 20px;
-      z-index: 2;
-      pointer-events: none;
-      transition: opacity 0.3s ease;
-      padding: 40px 0;
-      box-sizing: border-box;
-    }
-    .card.active .overlay {
-      opacity: 1;
-      pointer-events: auto;
     }
     .card-stack {
       position: relative;
@@ -112,47 +89,53 @@
       transition: opacity 0.3s ease-in-out, transform 0.3s ease-in-out;
       object-fit: contain;
       cursor: pointer;
+      pointer-events: none;
     }
     .variant-image.active {
       opacity: 1;
+      pointer-events: auto;
     }
-    .card-stack.show-stack .variant-image {
+    .card:hover .variant-image {
       opacity: 1;
+      pointer-events: auto;
     }
-    .card-stack.show-stack {
+    .card:hover .card-stack {
       transform: translateY(-5px) rotate(-1deg);
     }
-    .card-stack.show-stack .variant-image:nth-child(1) {
+    .card:hover .variant-image:nth-child(1) {
       transform: translate(-6px, 6px) rotate(-1deg);
     }
-    .card-stack.show-stack .variant-image:nth-child(2) {
+    .card:hover .variant-image:nth-child(2) {
       transform: translate(-2px, 2px) rotate(1deg);
     }
-    .card-stack.show-stack .variant-image:nth-child(3) {
+    .card:hover .variant-image:nth-child(3) {
       transform: translate(2px, -2px) rotate(-0.5deg);
     }
-    .card-stack.show-stack .variant-image:nth-child(4) {
-      transform: translate(6px, -6px) rotate(0.5deg);
+    .card:hover .variant-image:nth-child(4) {
+      transform: translate(0, 0) rotate(0deg);
     }
-    .variant-selector {
-      margin-top: 20px;
+    .condition-buttons {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      width: 100%;
       display: flex;
-      gap: 8px;
+      justify-content: space-around;
+      background: rgba(0, 0, 0, 0.3);
+      padding: 8px 0;
+      box-sizing: border-box;
     }
-    .variant-selector button {
-      padding: 6px 10px;
-      border: none;
+    .condition-buttons button {
+      background: rgba(255, 255, 255, 0.2);
+      color: #fff;
+      border: 1px solid #fff;
       border-radius: 4px;
+      padding: 4px 6px;
       cursor: pointer;
       font-weight: bold;
-      transition: background 0.2s ease;
     }
-    .variant-selector button:hover {
-      background: #555;
-      color: #fff;
-    }
-    .overlay .info {
-      text-align: center;
+    .condition-buttons button:hover {
+      background: rgba(255, 255, 255, 0.4);
     }
   </style>
   <link href="https://fonts.googleapis.com/css2?family=Bangers&display=swap" rel="stylesheet">

--- a/tests/fetchCardImages.test.js
+++ b/tests/fetchCardImages.test.js
@@ -94,8 +94,8 @@ function buildCard() {
   card.appendChild(price);
   card.appendChild(condition);
 
-  const priceMap = { NM: '$29.99', EX: '$27.50', LP: '$24.99', HP: '$19.99' };
-  const variants = ['NM', 'EX', 'LP', 'HP'].map(cond => {
+  const priceMap = { NM: '$29.99', VG: '$24.99', EX: '$19.99', G: '$9.99' };
+  const variants = ['NM', 'VG', 'EX', 'G'].map(cond => {
     const img = el('img', 'variant-image');
     img.dataset.condition = cond;
     img.dataset.price = priceMap[cond];
@@ -104,8 +104,8 @@ function buildCard() {
   });
   variants[0].classList.add('active');
 
-  const selector = el('div', 'variant-selector');
-  const buttons = ['NM', 'EX', 'LP', 'HP'].map(() => el('button'));
+  const selector = el('div', 'condition-buttons');
+  const buttons = ['NM', 'VG', 'EX', 'G'].map(() => el('button'));
   buttons.forEach(btn => selector.appendChild(btn));
   card.appendChild(selector);
 
@@ -115,17 +115,17 @@ function buildCard() {
 test('changeVariant reorders stack and updates labels', () => {
   const { card, stack, price, condition, buttons } = buildCard();
 
-  changeVariant(buttons[2], 'LP', '$24.99');
-  assert.equal(stack.lastElementChild.dataset.condition, 'LP');
-  assert.equal(stack.querySelector('.variant-image.active').dataset.condition, 'LP');
-  assert.equal(price.textContent, 'Price: $24.99');
-  assert.equal(condition.textContent, 'Condition: LP');
-
-  changeVariant(buttons[3], 'HP', '$19.99');
-  assert.equal(stack.lastElementChild.dataset.condition, 'HP');
-  assert.equal(stack.querySelector('.variant-image.active').dataset.condition, 'HP');
+  changeVariant(buttons[2], 'EX', '$19.99');
+  assert.equal(stack.lastElementChild.dataset.condition, 'EX');
+  assert.equal(stack.querySelector('.variant-image.active').dataset.condition, 'EX');
   assert.equal(price.textContent, 'Price: $19.99');
-  assert.equal(condition.textContent, 'Condition: HP');
+  assert.equal(condition.textContent, 'Condition: EX');
+
+  changeVariant(buttons[3], 'G', '$9.99');
+  assert.equal(stack.lastElementChild.dataset.condition, 'G');
+  assert.equal(stack.querySelector('.variant-image.active').dataset.condition, 'G');
+  assert.equal(price.textContent, 'Price: $9.99');
+  assert.equal(condition.textContent, 'Condition: G');
 
   assert.equal(stack.querySelectorAll('.variant-image').length, 4);
 });
@@ -133,9 +133,9 @@ test('changeVariant reorders stack and updates labels', () => {
 test('cycleVariant advances to next image', () => {
   const { stack, price, condition } = buildCard();
   cycleVariant(stack);
-  assert.equal(stack.lastElementChild.dataset.condition, 'EX');
-  assert.equal(stack.querySelector('.variant-image.active').dataset.condition, 'EX');
-  assert.equal(price.textContent, 'Price: $27.50');
-  assert.equal(condition.textContent, 'Condition: EX');
+  assert.equal(stack.lastElementChild.dataset.condition, 'VG');
+  assert.equal(stack.querySelector('.variant-image.active').dataset.condition, 'VG');
+  assert.equal(price.textContent, 'Price: $24.99');
+  assert.equal(condition.textContent, 'Condition: VG');
 });
 


### PR DESCRIPTION
## Summary
- Replace dark overlays with transparent condition buttons displaying inventory
- Hover reveals full card stack and allows selecting condition cards with shuffle effect
- Update tests for new condition variants

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acb099098883339682b3a3c54354d9