### PR TITLE
Fix card hover stacking

### DIFF
--- a/fetchCardImages.js
+++ b/fetchCardImages.js
@@ -53,6 +53,9 @@ async function fetchCardImages() {
       </div>
     `;
     const stack = cardDiv.querySelector('.card-stack');
+    // ensure the initially active image is the last child so it sits on top
+    const initialActive = stack.querySelector('.variant-image.active');
+    if (initialActive) stack.appendChild(initialActive);
 
     stack.querySelectorAll('.variant-image').forEach(img => {
       img.addEventListener('click', (e) => {

--- a/index.html
+++ b/index.html
@@ -90,10 +90,12 @@
       object-fit: contain;
       cursor: pointer;
       pointer-events: none;
+      z-index: 1;
     }
     .variant-image.active {
       opacity: 1;
       pointer-events: auto;
+      z-index: 5;
     }
     .card:hover .variant-image {
       opacity: 1;


### PR DESCRIPTION
## Summary
- Ensure initially active card image is moved to top of stack
- Add z-index rules so hover stack displays correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68accfc9f8788333a5383550db8f0553