### PR TITLE
Enable dynamic card stack rotation

### DIFF
--- a/fetchCardImages.js
+++ b/fetchCardImages.js
@@ -78,16 +78,21 @@ async function fetchCardImages() {
     if (initialActive) stack.appendChild(initialActive);
     applyOffsets(stack);
 
+    stack.addEventListener('click', (e) => {
+      e.stopPropagation();
+      cycleVariant(stack);
+    });
+
     stack.querySelectorAll('.variant-image').forEach(img => {
       img.addEventListener('click', (e) => {
         e.stopPropagation();
-        changeVariant(img, img.dataset.condition, img.dataset.price);
+        animateToCondition(cardDiv, img.dataset.condition);
       });
     });
     cardDiv.querySelectorAll('.condition-buttons button').forEach(btn => {
       btn.addEventListener('click', (e) => {
         e.stopPropagation();
-        changeVariant(btn, btn.dataset.condition, btn.dataset.price);
+        animateToCondition(cardDiv, btn.dataset.condition);
       });
     });
 
@@ -95,17 +100,13 @@ async function fetchCardImages() {
   }
 }
 
-function changeVariant(button, condition, price) {
+async function changeVariant(button, condition, price) {
   const card = button.closest('.card');
-  const stack = card.querySelector('.card-stack');
-  const images = Array.from(stack.querySelectorAll('.variant-image'));
-  const target = images.find(img => img.dataset.condition === condition);
-  images.forEach(img => img.classList.remove('active'));
-  target.classList.add('active');
-  stack.appendChild(target);
-  card.querySelector('.price').textContent = `Price: ${price}`;
-  card.querySelector('.condition').textContent = `Condition: ${condition}`;
-  applyOffsets(stack);
+  await animateToCondition(card, condition);
+  if (card) {
+    card.querySelector('.price').textContent = `Price: ${price}`;
+    card.querySelector('.condition').textContent = `Condition: ${condition}`;
+  }
 }
 
   function cycleVariant(stack) {
@@ -157,10 +158,11 @@ function changeVariant(button, condition, price) {
 
 // UMD-style export so function is available in browser and Node tests
 if (typeof module !== 'undefined') {
-  module.exports = { fetchCardImages, cardNames, changeVariant, cycleVariant };
+  module.exports = { fetchCardImages, cardNames, changeVariant, cycleVariant, animateToCondition };
 } else {
   window.fetchCardImages = fetchCardImages;
   window.cardNames = cardNames;
   window.changeVariant = changeVariant;
   window.cycleVariant = cycleVariant;
+  window.animateToCondition = animateToCondition;
 }

--- a/index.html
+++ b/index.html
@@ -94,6 +94,7 @@
     }
     .variant-image.active {
       z-index: 5;
+      pointer-events: none;
     }
     .card:hover .card-stack {
       transform: translateY(-5px) rotate(-1deg);

--- a/tests/fetchCardImages.test.js
+++ b/tests/fetchCardImages.test.js
@@ -130,16 +130,16 @@ function buildCard() {
   return { card, stack, price, condition, buttons };
 }
 
-test('changeVariant reorders stack and updates labels', () => {
+test('changeVariant reorders stack and updates labels', async () => {
   const { card, stack, price, condition, buttons } = buildCard();
 
-  changeVariant(buttons[2], 'EX', '$19.99');
+  await changeVariant(buttons[2], 'EX', '$19.99');
   assert.equal(stack.lastElementChild.dataset.condition, 'EX');
   assert.equal(stack.querySelector('.variant-image.active').dataset.condition, 'EX');
   assert.equal(price.textContent, 'Price: $19.99');
   assert.equal(condition.textContent, 'Condition: EX');
 
-  changeVariant(buttons[3], 'G', '$9.99');
+  await changeVariant(buttons[3], 'G', '$9.99');
   assert.equal(stack.lastElementChild.dataset.condition, 'G');
   assert.equal(stack.querySelector('.variant-image.active').dataset.condition, 'G');
   assert.equal(price.textContent, 'Price: $9.99');


### PR DESCRIPTION
## Summary
- Allow clicking the card stack to cycle through all four variants
- Disable pointer events on the active card so underlying cards are clickable
- Animate variant changes and export helper for tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad0ac12a388333a844f801c82e15f7