### PR TITLE
Enable double-click cart add and improve login button

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ and displays them in a two-column grid with interactive hover overlays showing p
 - Fetches MTG card art from the Scryfall API
 - Hover overlay showing placeholder price, rarity, condition, and inventory data
 - Variant selector for different conditions/prices
+- Double-click card art to add it to your cart and remove items from the cart menu
 
 *Future versions aim to source real pricing and inventory data.*
 

--- a/fetchCardImages.js
+++ b/fetchCardImages.js
@@ -78,7 +78,6 @@ async function fetchCardImages() {
         <button data-condition="VG" data-price="${prices.VG}">VG (${inventory.VG})</button>
         <button data-condition="EX" data-price="${prices.EX}">EX (${inventory.EX})</button>
         <button data-condition="G" data-price="${prices.G}">G (${inventory.G})</button>
-        <button class="add-to-cart">Add to Cart</button>
       </div>
     `;
     const stack = cardDiv.querySelector('.card-stack');
@@ -87,9 +86,14 @@ async function fetchCardImages() {
     if (initialActive) stack.appendChild(initialActive);
     applyOffsets(stack);
 
+    let clickTimer;
     stack.addEventListener('click', (e) => {
       e.stopPropagation();
-      cycleVariant(stack);
+      if (clickTimer) clearTimeout(clickTimer);
+      clickTimer = setTimeout(() => {
+        cycleVariant(stack);
+        clickTimer = null;
+      }, 200);
     });
 
     stack.querySelectorAll('.variant-image').forEach(img => {
@@ -101,15 +105,17 @@ async function fetchCardImages() {
     cardDiv.querySelectorAll('.condition-buttons button').forEach(btn => {
       btn.addEventListener('click', (e) => {
         e.stopPropagation();
-        if (btn.classList.contains('add-to-cart')) {
-          const active = cardDiv.querySelector('.variant-image.active');
-          if (active && typeof addToCart === 'function') {
-            addToCart({ name, condition: active.dataset.condition, price: active.dataset.price });
-          }
-        } else {
-          animateToCondition(cardDiv, btn.dataset.condition);
-        }
+        animateToCondition(cardDiv, btn.dataset.condition);
       });
+    });
+
+    cardDiv.addEventListener('dblclick', (e) => {
+      e.stopPropagation();
+      if (clickTimer) { clearTimeout(clickTimer); clickTimer = null; }
+      const active = cardDiv.querySelector('.variant-image.active');
+      if (active && typeof addToCart === 'function') {
+        addToCart({ name, condition: active.dataset.condition, price: active.dataset.price });
+      }
     });
 
     grid.appendChild(cardDiv);

--- a/index.html
+++ b/index.html
@@ -94,10 +94,20 @@
       padding: 12px 0;
       box-sizing: border-box;
     }
-    .condition-buttons .add-to-cart {
-      background: #ffd700;
-      color: #333;
-      border-color: #ffd700;
+    #loginBtn {
+      background: linear-gradient(45deg, #d92626, #ff7e5f);
+      color: #fff;
+      border: none;
+      padding: 10px 20px;
+      border-radius: 8px;
+      font-size: 18px;
+      font-weight: bold;
+      cursor: pointer;
+      transition: transform 0.2s, box-shadow 0.2s;
+    }
+    #loginBtn:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
     }
     .grid {
       display: grid;


### PR DESCRIPTION
## Summary
- Allow shoppers to double-click any card to add it to the cart
- Style the login button with a vibrant gradient and hover effect to match the site theme
- Document cart interaction including removal capability

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad2a065fa08333b4639d6ba7e8181b