### PR TITLE
Restore two-column layout and improve card stack visuals

### DIFF
--- a/fetchCardImages.js
+++ b/fetchCardImages.js
@@ -28,9 +28,9 @@ const inventory = {
 function applyOffsets(stack) {
   const images = Array.from(stack.querySelectorAll('.variant-image'));
   const preset = [
-    { x: -20, y: -20, r: -4 },
-    { x: -10, y: 10, r: -2 },
-    { x: 10, y: -10, r: 2 },
+    { x: -12, y: -12, r: -3 },
+    { x: -6, y: 6, r: -1.5 },
+    { x: 6, y: -6, r: 1.5 },
     { x: 0, y: 0, r: 0 }
   ];
 

--- a/index.html
+++ b/index.html
@@ -111,8 +111,8 @@
     }
     .grid {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      gap: 20px;
+      grid-template-columns: repeat(2, minmax(260px, 1fr));
+      gap: 40px;
       padding: 20px;
       justify-content: center;
     }
@@ -121,7 +121,7 @@
       width: 100%;
       max-width: 512px;
       aspect-ratio: 512 / 716;
-      overflow: hidden;
+      overflow: visible;
       margin: 0 auto 20px;
       transition: transform 0.3s ease, box-shadow 0.3s ease;
     }
@@ -153,6 +153,7 @@
       cursor: pointer;
       z-index: 1;
       backface-visibility: hidden;
+      box-shadow: 0 0 0 2px #fff;
     }
     .variant-image.active {
       z-index: 5;
@@ -199,6 +200,10 @@
       .content {
         flex-direction: column;
         align-items: center;
+      }
+      .grid {
+        grid-template-columns: 1fr;
+        gap: 20px;
       }
       .right-sidebar {
         width: 100%;


### PR DESCRIPTION
## Summary
- Maintain a two-column card grid that falls back to a single column on small screens
- Show full card stack edges by allowing overflow and adding white outlines
- Adjust stack offsets for a more natural spread

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae3040307483339ccd7b2b1ec56555