### PR TITLE
Only fan out card stack on hover

### DIFF
--- a/fetchCardImages.js
+++ b/fetchCardImages.js
@@ -53,6 +53,13 @@ function applyOffsets(stack) {
   if (active && active.style) active.style.zIndex = images.length + 10;
 }
 
+function resetOffsets(stack) {
+  const images = Array.from(stack.querySelectorAll('.variant-image'));
+  images.forEach(img => {
+    img.style.transform = 'translate(0px, 0px) rotate(0deg)';
+  });
+}
+
 async function fetchCardImages() {
   const grid = document.getElementById("cardGrid");
   for (let name of cardNames) {
@@ -86,6 +93,18 @@ async function fetchCardImages() {
     const initialActive = stack.querySelector('.variant-image.active');
     if (initialActive) stack.appendChild(initialActive);
     applyOffsets(stack);
+    resetOffsets(stack);
+    stack._hovered = false;
+
+    cardDiv.addEventListener('mouseenter', () => {
+      stack._hovered = true;
+      applyOffsets(stack);
+    });
+
+    cardDiv.addEventListener('mouseleave', () => {
+      stack._hovered = false;
+      resetOffsets(stack);
+    });
 
     let clickTimer;
     stack.addEventListener('click', (e) => {
@@ -185,6 +204,7 @@ async function changeVariant(button, condition, price) {
           card.querySelector('.condition').textContent = `Condition: ${next.dataset.condition}`;
         }
         applyOffsets(stack);
+        if (!stack._hovered) resetOffsets(stack);
         resolve();
       }, 300);
     });

--- a/index.html
+++ b/index.html
@@ -128,8 +128,9 @@
     .card img {
       width: 100%;
       height: 100%;
-      object-fit: contain;
+      object-fit: cover;
       display: block;
+      border-radius: 24px;
     }
     .card:hover {
       transform: translateY(-10px) scale(1.02);
@@ -149,10 +150,11 @@
       width: 100%;
       height: 100%;
       transition: transform 0.3s ease-in-out;
-      object-fit: contain;
+      object-fit: cover;
       cursor: pointer;
       z-index: 1;
       backface-visibility: hidden;
+      border-radius: 24px;
     }
     .variant-image.active {
       z-index: 5;


### PR DESCRIPTION
## Summary
- Display card stacks only when hovering over a card
- Reset stack layout when not hovered to show a single card
- Round card image corners to match real card dimensions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae38f6bbe883339d7c079040421a5f