### PR TITLE
Show stack on hover and fix mobile layout

### DIFF
--- a/fetchCardImages.js
+++ b/fetchCardImages.js
@@ -96,13 +96,15 @@ async function fetchCardImages() {
     resetOffsets(stack);
     stack._hovered = false;
 
-    cardDiv.addEventListener('mouseenter', () => {
+    cardDiv.addEventListener('pointerenter', () => {
       stack._hovered = true;
+      stack.classList.add('show-stack');
       applyOffsets(stack);
     });
 
-    cardDiv.addEventListener('mouseleave', () => {
+    cardDiv.addEventListener('pointerleave', () => {
       stack._hovered = false;
+      stack.classList.remove('show-stack');
       resetOffsets(stack);
     });
 

--- a/index.html
+++ b/index.html
@@ -149,18 +149,24 @@
       left: 0;
       width: 100%;
       height: 100%;
-      transition: transform 0.3s ease-in-out;
+      transition: transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
       object-fit: cover;
       cursor: pointer;
       z-index: 1;
       backface-visibility: hidden;
       border-radius: 24px;
+      opacity: 0;
     }
     .variant-image.active {
       z-index: 5;
       pointer-events: none;
+      opacity: 1;
     }
-    .card:hover .card-stack {
+    .card-stack.show-stack .variant-image {
+      opacity: 1;
+    }
+    .card:hover .card-stack,
+    .card-stack.show-stack {
       transform: translateY(-5px) rotate(-1deg);
     }
     .variant-image.flipping {
@@ -223,6 +229,12 @@
         padding-left: 0;
         align-items: center;
         margin-top: 20px;
+      }
+      .grid {
+        padding: 10px;
+      }
+      .card {
+        max-width: 100%;
       }
     }
   </style>


### PR DESCRIPTION
## Summary
- Hide non-active card images until hovered or tapped, with pointer-aware events and class toggling
- Refine mobile grid and card sizing for better responsiveness

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae3f92a5c483338898e0333a4c72aa